### PR TITLE
r/certificate: Allow for recursive nameservers to be overridden

### DIFF
--- a/acme/test_forwarder_test.go
+++ b/acme/test_forwarder_test.go
@@ -1,0 +1,125 @@
+package acme
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/miekg/dns"
+)
+
+const forwardingAddress = "8.8.8.8:53"
+
+// testForwarder is a DNS forwarder designed to test the custom
+// propagation nameserver functionality.
+type testForwarder struct {
+	called bool
+	conn   net.PacketConn
+	server *dns.Server
+}
+
+// newTestForwarder creates a new testForwarder and starts it.
+// Call LocalAddr after creation to get the address after creation.
+func newTestForwarder() (*testForwarder, error) {
+	f := new(testForwarder)
+	var err error
+	f.conn, err = net.ListenPacket("udp", ":0")
+	if err != nil {
+		return nil, err
+	}
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", f.forward)
+	f.server = &dns.Server{
+		Handler:    mux,
+		PacketConn: f.conn,
+	}
+
+	log.Printf("[DEBUG] new test forwarding DNS server registered at %s", f.conn.LocalAddr())
+	f.start()
+	return f, nil
+}
+
+// LocalAddr returns the local address of the test forwarder as a
+// string.
+func (f *testForwarder) LocalAddr() string {
+	return f.conn.LocalAddr().String()
+}
+
+// Called returns true if the testForwarder has seen traffic.
+func (f *testForwarder) Called() bool {
+	return f.called
+}
+
+// start starts the DNS server in a new goroutine. Errors operating
+// the server result in a panic.
+//
+// Make sure to call Shutdown when finished as to not leak the
+// goroutine started by this function.
+func (f *testForwarder) start() {
+	go func() {
+		log.Printf("[DEBUG] starting test forwarding DNS server on %s", f.conn.LocalAddr())
+		if err := f.server.ActivateAndServe(); err != nil {
+			panic(err)
+		}
+
+		log.Printf("[DEBUG] test forwarding DNS server on %s shutting down", f.conn.LocalAddr())
+	}()
+}
+
+// Shutdown shuts down the DNS server and should be called when the
+// test is complete. It panics on errors.
+func (f *testForwarder) Shutdown() {
+	if err := f.server.Shutdown(); err != nil {
+		panic(err)
+	}
+}
+
+// forward sends DNS traffic to the forwarding address
+func (f *testForwarder) forward(r dns.ResponseWriter, msg *dns.Msg) {
+	f.called = true
+	defer r.Close()
+	log.Printf("[DEBUG] query from %s: \n  %s", r.RemoteAddr(), f.questions(msg.Question))
+
+	c := new(dns.Client)
+	resp, rtt, err := c.Exchange(msg, forwardingAddress)
+	if err != nil {
+		log.Printf("[DEBUG] error forwarding test DNS request: %s", err)
+	}
+
+	log.Printf("[DEBUG] reply from %s (RTT=%d): \n  %s", forwardingAddress, rtt, f.answers(resp.Answer))
+	if err := r.WriteMsg(resp); err != nil {
+		log.Printf("[DEBUG] error relaying back forwarded DNS response: %s", err)
+	}
+}
+
+func (f *testForwarder) Check() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if !f.Called() {
+			return fmt.Errorf("no DNS records were sent through %s", f.conn.LocalAddr())
+		}
+
+		return nil
+	}
+}
+
+func (f *testForwarder) questions(qs []dns.Question) string {
+	var result []string
+	for _, q := range qs {
+		result = append(result, q.String())
+	}
+
+	return strings.Join(result, "\n  ")
+}
+
+func (f *testForwarder) answers(rrs []dns.RR) string {
+	var result []string
+	for _, rr := range rrs {
+		result = append(result, rr.String())
+	}
+
+	return strings.Join(result, "\n  ")
+}

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 // indirect
 	github.com/linode/linodego v0.7.1 // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect
-	github.com/miekg/dns v1.1.4 // indirect
+	github.com/miekg/dns v1.1.4
 	github.com/mitchellh/cli v0.0.0-20180414170447-c48282d14eba // indirect
 	github.com/mitchellh/copystructure v0.0.0-20170525013902-d23ffcb85de3 // indirect
 	github.com/mitchellh/go-homedir v0.0.0-20180523094522-3864e76763d9 // indirect

--- a/website/docs/r/certificate.html.markdown
+++ b/website/docs/r/certificate.html.markdown
@@ -180,7 +180,7 @@ Example with the [Route 53 provider][route53-dns-provider]:
 
 ```hcl
 resource "acme_certificate" "certificate" {
-  ...
+  #...
 
   dns_challenge {
     provider = "route53"
@@ -192,7 +192,31 @@ resource "acme_certificate" "certificate" {
     }
   }
 
-  ...
+  #...
+}
+```
+
+#### Manually specifying recursive nameservers for propagation checks
+
+The ACME provider will normally use your system-configured DNS resolvers to
+check for propagation of the TXT records before proceeding with the certificate
+request. In split horizon scenarios, this check may never succeed, as the
+machine running Terraform may not have visibility into these public DNS
+records.
+
+To override this default behavior, supply the `recursive_nameservers` to use as
+a list in `host:port` form within the `dns_challenge` block:
+
+```hcl
+resource "acme_certificate" "certificate" {
+  #...
+
+  dns_challenge {
+    provider              = "route53"
+    recursive_nameservers = ["8.8.8.8:53"]
+  }
+
+  #...
 }
 ```
 


### PR DESCRIPTION
This adds the `recursive_nameservers` option to the DNS challenge section
of the acme_certificate resource, allowing for the override of the
system default nameservers used for DNS propagation checks.

This is useful for split-horizon scenarios where Terraform is being run
in a location in the network where a local zone will prevent visibility
into the public TXT records, which will normally cause the provider to
fail, as it will never see the added records.