### PR TITLE
r/certificate: Add PKCS12 export field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	gopkg.in/ns1/ns1-go.v2 v2.0.0-20181211201113-a57b2a18aab6 // indirect
 	gopkg.in/resty.v1 v1.11.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.1.6 // indirect
+	software.sslmate.com/src/go-pkcs12 v0.0.0-20190209200317-47dd539968c4
 )
 
 replace github.com/ldez/go-auroradns => github.com/ldez/go-auroradns/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -311,3 +311,5 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20180920025451-e3ad64cb4ed3/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20190209200317-47dd539968c4 h1:bgAHvGcJ9+ho1l9ItDc5F14pNQ4iZnd65UHEYwJLbrI=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20190209200317-47dd539968c4/go.mod h1:/xvNRWUqm0+/ZMiF4EX00vrSCMsE4/NHb+Pt3freEeQ=

--- a/website/docs/r/certificate.html.markdown
+++ b/website/docs/r/certificate.html.markdown
@@ -246,3 +246,6 @@ The following attributes are exported:
   `certificate_request_pem` was used, this will be blank.
 * `certificate_pem` - The certificate in PEM format.
 * `issuer_pem` - The intermediate certificate of the issuer.
+* `certificate_p12` - The certificate, intermediate, and any private key archived
+  as a PFX file (PKCS12 format, generally used by Microsoft products). The data
+  is base64 encoded and has no password.


### PR DESCRIPTION
This is to assist with resources/services that take PKCS12 directly, ie:
Azure.

The certificate, intermediate, and private key are all exported into
the PFX archive and the contents are base64 encoded. No password is set.