### PR TITLE
r/certificate: No partial, dns_challenge is list, no longer ForceNew

### DIFF
--- a/acme/acme_structure.go
+++ b/acme/acme_structure.go
@@ -1,17 +1,14 @@
 package acme
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"os"
-	"sort"
 	"time"
 
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/xenolf/lego/certcrypto"
 	"github.com/xenolf/lego/certificate"
@@ -142,9 +139,8 @@ func certificateSchema() map[string]*schema.Schema {
 			Default:  7,
 		},
 		"dns_challenge": {
-			Type:     schema.TypeSet,
+			Type:     schema.TypeList,
 			Required: true,
-			Set:      dnsChallengeSetHash,
 			MaxItems: 1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
@@ -160,7 +156,6 @@ func certificateSchema() map[string]*schema.Schema {
 					},
 				},
 			},
-			ForceNew: true,
 		},
 		"must_staple": {
 			Type:     schema.TypeBool,
@@ -573,24 +568,6 @@ func setDNSChallenge(client *lego.Client, m map[string]interface{}) error {
 	}
 
 	return nil
-}
-
-// dnsChallengeSetHash computes the hash for the DNS challenge.
-func dnsChallengeSetHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["provider"].(string)))
-	// sort the keys first so that the hash is consistent every time
-	keys := []string{}
-	for k := range m["config"].(map[string]interface{}) {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	// now write out the hash values
-	for _, k := range keys {
-		buf.WriteString(fmt.Sprintf("%s-%s-", k, m["config"].(map[string]interface{})[k].(string)))
-	}
-	return hashcode.String(buf.String())
 }
 
 // stringSlice converts an interface slice to a string slice.


### PR DESCRIPTION
I wrote this provider when my understanding of Terraform was not 100%
complete, this fixes some issues that were the result of that:

* Partial state mode was probably never needed and as such has been
removed. No attributes are set in a way that would produce an
inconsistent state mid-flight.
* Complex structures should be lists, not sets. This prevents odd
hash issues from coming up when changing values in blocks that are
especially restricted to just one element only. dns_challenge is one
of these items and as such has been modified to be a list.
* Not necessarily a mistake in schema design, but `dns_challenge`
configuration items do not need to be ForceNew, as it's perfectly
reasonable that DNS might migrate providers during the lifetime of a
certificate, and since DNS is only used for validating a challenge,
it technically has nothing to do with the rest of the certificate
data. As such this has been removed and one can now change DNS
challenge settings in the middle of a certificate's lifetime without
having to re-create the certificate.

Fixes #1.