### PR TITLE
r/certificate: subject_alternative_names doesn't need a Set func

### DIFF
--- a/acme/acme_structure.go
+++ b/acme/acme_structure.go
@@ -118,7 +118,6 @@ func certificateSchema() map[string]*schema.Schema {
 			Type:          schema.TypeSet,
 			Optional:      true,
 			Elem:          &schema.Schema{Type: schema.TypeString},
-			Set:           schema.HashString,
 			ForceNew:      true,
 			ConflictsWith: []string{"certificate_request_pem"},
 		},


### PR DESCRIPTION
The `Set` func on this attribute was set to `schema.HashString`, which is
actually what `helper/schema` defaults a `TypeSet` with an element of
this type to anyway.

Removed it and tested on a config with a few SANs, no change.