### PR TITLE
Add challenge support for multiple DNS providers

### DIFF
--- a/acme/acme_migrations.go
+++ b/acme/acme_migrations.go
@@ -104,13 +104,17 @@ func migrateACMECertificateStateV4(is *terraform.InstanceState, meta interface{}
 			continue
 		}
 
+		if path[0] != "dns_challenge" {
+			continue
+		}
+
 		if path[2] != "recursive_nameservers" {
 			continue
 		}
 
 		// Re-write recursive_nameservers to the root scope.
 		delete(is.Attributes, k)
-		is.Attributes[strings.Join(path[2:], ".")] = v
+		is.Attributes["recursive_nameservers"] = v
 	}
 
 	return nil

--- a/acme/acme_migrations_test.go
+++ b/acme/acme_migrations_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -37,17 +38,19 @@ func testACMECertificateStateDataV0() *terraform.InstanceState {
 	return &terraform.InstanceState{
 		ID: "certurl",
 		Attributes: map[string]string{
-			"server_url":                               "https://acme-staging.api.letsencrypt.org/directory",
-			"account_key_pem":                          "key",
-			"common_name":                              "foobar",
-			"subject_alternative_names.#":              "2",
-			"subject_alternative_names.0":              "barbar",
-			"subject_alternative_names.1":              "bazbar",
-			"key_type":                                 "2048",
-			"certificate_request_pem":                  "req",
-			"min_days_remaining":                       "30",
-			"dns_challenge.#":                          "1",
-			"dns_challenge.1234.provider":              "route53",
+			"server_url":                  "https://acme-staging.api.letsencrypt.org/directory",
+			"account_key_pem":             "key",
+			"common_name":                 "foobar",
+			"subject_alternative_names.#": "2",
+			"subject_alternative_names.0": "barbar",
+			"subject_alternative_names.1": "bazbar",
+			"key_type":                    "2048",
+			"certificate_request_pem":     "req",
+			"min_days_remaining":          "30",
+			"dns_challenge.#":             "1",
+			"dns_challenge.1234.provider": "route53",
+			// Workaround for E2E migration test. recursive_nameservers is
+			// not a part of schema at this version.
 			"dns_challenge.1234.recursive_nameservers": "my.name.server",
 			"http_challenge_port":                      "80",
 			"tls_challenge_port":                       "443",
@@ -66,23 +69,25 @@ func testACMECertificateStateDataV1() *terraform.InstanceState {
 	return &terraform.InstanceState{
 		ID: "certurl",
 		Attributes: map[string]string{
-			"account_key_pem":                          "key",
-			"common_name":                              "foobar",
-			"subject_alternative_names.#":              "2",
-			"subject_alternative_names.0":              "barbar",
-			"subject_alternative_names.1":              "bazbar",
-			"key_type":                                 "2048",
-			"certificate_request_pem":                  "req",
-			"min_days_remaining":                       "30",
-			"dns_challenge.#":                          "1",
-			"dns_challenge.1234.provider":              "route53",
+			"account_key_pem":             "key",
+			"common_name":                 "foobar",
+			"subject_alternative_names.#": "2",
+			"subject_alternative_names.0": "barbar",
+			"subject_alternative_names.1": "bazbar",
+			"key_type":                    "2048",
+			"certificate_request_pem":     "req",
+			"min_days_remaining":          "30",
+			"dns_challenge.#":             "1",
+			"dns_challenge.1234.provider": "route53",
+			// Workaround for E2E migration test. recursive_nameservers is
+			// not a part of schema at this version.
 			"dns_challenge.1234.recursive_nameservers": "my.name.server",
-			"must_staple":                              "0",
-			"certificate_domain":                       "foobar",
-			"account_ref":                              "regurl",
-			"private_key_pem":                          "certkey",
-			"certificate_pem":                          "certpem",
-			"certificate_url":                          "certurl",
+			"must_staple":        "0",
+			"certificate_domain": "foobar",
+			"account_ref":        "regurl",
+			"private_key_pem":    "certkey",
+			"certificate_pem":    "certpem",
+			"certificate_url":    "certurl",
 		},
 	}
 }
@@ -91,22 +96,24 @@ func testACMECertificateStateDataV2() *terraform.InstanceState {
 	return &terraform.InstanceState{
 		ID: "certurl",
 		Attributes: map[string]string{
-			"account_key_pem":                          "key",
-			"common_name":                              "foobar",
-			"subject_alternative_names.#":              "2",
-			"subject_alternative_names.0":              "barbar",
-			"subject_alternative_names.1":              "bazbar",
-			"key_type":                                 "2048",
-			"certificate_request_pem":                  "req",
-			"min_days_remaining":                       "30",
-			"dns_challenge.#":                          "1",
-			"dns_challenge.1234.provider":              "route53",
+			"account_key_pem":             "key",
+			"common_name":                 "foobar",
+			"subject_alternative_names.#": "2",
+			"subject_alternative_names.0": "barbar",
+			"subject_alternative_names.1": "bazbar",
+			"key_type":                    "2048",
+			"certificate_request_pem":     "req",
+			"min_days_remaining":          "30",
+			"dns_challenge.#":             "1",
+			"dns_challenge.1234.provider": "route53",
+			// Workaround for E2E migration test. recursive_nameservers is
+			// not a part of schema at this version.
 			"dns_challenge.1234.recursive_nameservers": "my.name.server",
-			"must_staple":                              "0",
-			"certificate_domain":                       "foobar",
-			"private_key_pem":                          "certkey",
-			"certificate_pem":                          "certpem",
-			"certificate_url":                          "certurl",
+			"must_staple":        "0",
+			"certificate_domain": "foobar",
+			"private_key_pem":    "certkey",
+			"certificate_pem":    "certpem",
+			"certificate_url":    "certurl",
 		},
 	}
 }
@@ -167,7 +174,7 @@ func TestResourceACMERegistrationMigrateState(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("expected %#v, got %#v", expected, actual)
+		t.Fatalf("\n\nexpected:\n\n%s\n\ngot:\n\n%s\n\n", spew.Sdump(expected), spew.Sdump(actual))
 	}
 }
 
@@ -179,7 +186,7 @@ func TestMigrateACMERegistrationStateV1(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("expected %#v, got %#v", expected, actual)
+		t.Fatalf("\n\nexpected:\n\n%s\n\ngot:\n\n%s\n\n", spew.Sdump(expected), spew.Sdump(actual))
 	}
 }
 
@@ -191,7 +198,7 @@ func TestResourceACMECertificateMigrateState(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("expected %#v, got %#v", expected, actual)
+		t.Fatalf("\n\nexpected:\n\n%s\n\ngot:\n\n%s\n\n", spew.Sdump(expected), spew.Sdump(actual))
 	}
 }
 
@@ -203,7 +210,7 @@ func TestMigrateACMECertificateStateV4(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("expected %#v, got %#v", expected, actual)
+		t.Fatalf("\n\nexpected:\n\n%s\n\ngot:\n\n%s\n\n", spew.Sdump(expected), spew.Sdump(actual))
 	}
 }
 
@@ -215,7 +222,7 @@ func TestMigrateACMECertificateStateV3(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("expected %#v, got %#v", expected, actual)
+		t.Fatalf("\n\nexpected:\n\n%s\n\ngot:\n\n%s\n\n", spew.Sdump(expected), spew.Sdump(actual))
 	}
 }
 
@@ -227,7 +234,7 @@ func TestMigrateACMECertificateStateV2(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("expected %#v, got %#v", expected, actual)
+		t.Fatalf("\n\nexpected:\n\n%s\n\ngot:\n\n%s\n\n", spew.Sdump(expected), spew.Sdump(actual))
 	}
 }
 
@@ -239,6 +246,6 @@ func TestMigrateACMECertificateStateV1(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("expected %#v, got %#v", expected, actual)
+		t.Fatalf("\n\nexpected:\n\n%s\n\ngot:\n\n%s\n\n", spew.Sdump(expected), spew.Sdump(actual))
 	}
 }

--- a/acme/acme_migrations_test.go
+++ b/acme/acme_migrations_test.go
@@ -37,26 +37,27 @@ func testACMECertificateStateDataV0() *terraform.InstanceState {
 	return &terraform.InstanceState{
 		ID: "certurl",
 		Attributes: map[string]string{
-			"server_url":                  "https://acme-staging.api.letsencrypt.org/directory",
-			"account_key_pem":             "key",
-			"common_name":                 "foobar",
-			"subject_alternative_names.#": "2",
-			"subject_alternative_names.0": "barbar",
-			"subject_alternative_names.1": "bazbar",
-			"key_type":                    "2048",
-			"certificate_request_pem":     "req",
-			"min_days_remaining":          "30",
-			"dns_challenge.#":             "1",
-			"dns_challenge.1234.provider": "route53",
-			"http_challenge_port":         "80",
-			"tls_challenge_port":          "443",
-			"registration_url":            "regurl",
-			"must_staple":                 "0",
-			"certificate_domain":          "foobar",
-			"certificate_url":             "certurl",
-			"account_ref":                 "regurl",
-			"private_key_pem":             "certkey",
-			"certificate_pem":             "certpem",
+			"server_url":                               "https://acme-staging.api.letsencrypt.org/directory",
+			"account_key_pem":                          "key",
+			"common_name":                              "foobar",
+			"subject_alternative_names.#":              "2",
+			"subject_alternative_names.0":              "barbar",
+			"subject_alternative_names.1":              "bazbar",
+			"key_type":                                 "2048",
+			"certificate_request_pem":                  "req",
+			"min_days_remaining":                       "30",
+			"dns_challenge.#":                          "1",
+			"dns_challenge.1234.provider":              "route53",
+			"dns_challenge.1234.recursive_nameservers": "my.name.server",
+			"http_challenge_port":                      "80",
+			"tls_challenge_port":                       "443",
+			"registration_url":                         "regurl",
+			"must_staple":                              "0",
+			"certificate_domain":                       "foobar",
+			"certificate_url":                          "certurl",
+			"account_ref":                              "regurl",
+			"private_key_pem":                          "certkey",
+			"certificate_pem":                          "certpem",
 		},
 	}
 }
@@ -65,22 +66,23 @@ func testACMECertificateStateDataV1() *terraform.InstanceState {
 	return &terraform.InstanceState{
 		ID: "certurl",
 		Attributes: map[string]string{
-			"account_key_pem":             "key",
-			"common_name":                 "foobar",
-			"subject_alternative_names.#": "2",
-			"subject_alternative_names.0": "barbar",
-			"subject_alternative_names.1": "bazbar",
-			"key_type":                    "2048",
-			"certificate_request_pem":     "req",
-			"min_days_remaining":          "30",
-			"dns_challenge.#":             "1",
-			"dns_challenge.1234.provider": "route53",
-			"must_staple":                 "0",
-			"certificate_domain":          "foobar",
-			"account_ref":                 "regurl",
-			"private_key_pem":             "certkey",
-			"certificate_pem":             "certpem",
-			"certificate_url":             "certurl",
+			"account_key_pem":                          "key",
+			"common_name":                              "foobar",
+			"subject_alternative_names.#":              "2",
+			"subject_alternative_names.0":              "barbar",
+			"subject_alternative_names.1":              "bazbar",
+			"key_type":                                 "2048",
+			"certificate_request_pem":                  "req",
+			"min_days_remaining":                       "30",
+			"dns_challenge.#":                          "1",
+			"dns_challenge.1234.provider":              "route53",
+			"dns_challenge.1234.recursive_nameservers": "my.name.server",
+			"must_staple":                              "0",
+			"certificate_domain":                       "foobar",
+			"account_ref":                              "regurl",
+			"private_key_pem":                          "certkey",
+			"certificate_pem":                          "certpem",
+			"certificate_url":                          "certurl",
 		},
 	}
 }
@@ -89,26 +91,51 @@ func testACMECertificateStateDataV2() *terraform.InstanceState {
 	return &terraform.InstanceState{
 		ID: "certurl",
 		Attributes: map[string]string{
-			"account_key_pem":             "key",
-			"common_name":                 "foobar",
-			"subject_alternative_names.#": "2",
-			"subject_alternative_names.0": "barbar",
-			"subject_alternative_names.1": "bazbar",
-			"key_type":                    "2048",
-			"certificate_request_pem":     "req",
-			"min_days_remaining":          "30",
-			"dns_challenge.#":             "1",
-			"dns_challenge.1234.provider": "route53",
-			"must_staple":                 "0",
-			"certificate_domain":          "foobar",
-			"private_key_pem":             "certkey",
-			"certificate_pem":             "certpem",
-			"certificate_url":             "certurl",
+			"account_key_pem":                          "key",
+			"common_name":                              "foobar",
+			"subject_alternative_names.#":              "2",
+			"subject_alternative_names.0":              "barbar",
+			"subject_alternative_names.1":              "bazbar",
+			"key_type":                                 "2048",
+			"certificate_request_pem":                  "req",
+			"min_days_remaining":                       "30",
+			"dns_challenge.#":                          "1",
+			"dns_challenge.1234.provider":              "route53",
+			"dns_challenge.1234.recursive_nameservers": "my.name.server",
+			"must_staple":                              "0",
+			"certificate_domain":                       "foobar",
+			"private_key_pem":                          "certkey",
+			"certificate_pem":                          "certpem",
+			"certificate_url":                          "certurl",
 		},
 	}
 }
 
 func testACMECertificateStateDataV3() *terraform.InstanceState {
+	return &terraform.InstanceState{
+		ID: "certurl",
+		Attributes: map[string]string{
+			"account_key_pem":                       "key",
+			"common_name":                           "foobar",
+			"subject_alternative_names.#":           "2",
+			"subject_alternative_names.0":           "barbar",
+			"subject_alternative_names.1":           "bazbar",
+			"key_type":                              "2048",
+			"certificate_request_pem":               "req",
+			"min_days_remaining":                    "30",
+			"dns_challenge.#":                       "1",
+			"dns_challenge.0.provider":              "route53",
+			"dns_challenge.0.recursive_nameservers": "my.name.server",
+			"must_staple":                           "0",
+			"certificate_domain":                    "foobar",
+			"private_key_pem":                       "certkey",
+			"certificate_pem":                       "certpem",
+			"certificate_url":                       "certurl",
+		},
+	}
+}
+
+func testACMECertificateStateDataV4() *terraform.InstanceState {
 	return &terraform.InstanceState{
 		ID: "certurl",
 		Attributes: map[string]string{
@@ -122,6 +149,7 @@ func testACMECertificateStateDataV3() *terraform.InstanceState {
 			"min_days_remaining":          "30",
 			"dns_challenge.#":             "1",
 			"dns_challenge.0.provider":    "route53",
+			"recursive_nameservers":       "my.name.server",
 			"must_staple":                 "0",
 			"certificate_domain":          "foobar",
 			"private_key_pem":             "certkey",
@@ -156,9 +184,21 @@ func TestMigrateACMERegistrationStateV1(t *testing.T) {
 }
 
 func TestResourceACMECertificateMigrateState(t *testing.T) {
-	expected := testACMECertificateStateDataV3()
+	expected := testACMECertificateStateDataV4()
 	actual, err := resourceACMECertificateMigrateState(0, testACMECertificateStateDataV0(), nil)
 	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %#v, got %#v", expected, actual)
+	}
+}
+
+func TestMigrateACMECertificateStateV4(t *testing.T) {
+	expected := testACMECertificateStateDataV4()
+	actual := testACMECertificateStateDataV3()
+	if err := migrateACMECertificateStateV4(actual, nil); err != nil {
 		t.Fatalf("error migrating state: %s", err)
 	}
 

--- a/acme/acme_structure.go
+++ b/acme/acme_structure.go
@@ -148,7 +148,6 @@ func certificateSchema() map[string]*schema.Schema {
 		"dns_challenge": {
 			Type:     schema.TypeList,
 			Required: true,
-			MaxItems: 1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"provider": {
@@ -509,7 +508,7 @@ func mapEnvironmentVariableValues(keyMapping map[string]string) {
 // setDNSChallenge takes a *lego.Client and the DNS challenge complex
 // structure as a map[string]interface{}, and configues the client to
 // only allow a DNS challenge with the configured provider.
-func setDNSChallenge(client *lego.Client, m map[string]interface{}) error {
+func setDNSChallenge(client *lego.Client, m map[string]interface{}) (challenge.Provider, []dns01.ChallengeOption, error) {
 	var provider challenge.Provider
 	var err error
 	var providerName string
@@ -517,7 +516,7 @@ func setDNSChallenge(client *lego.Client, m map[string]interface{}) error {
 	if v, ok := m["provider"]; ok && v.(string) != "" {
 		providerName = v.(string)
 	} else {
-		return fmt.Errorf("DNS challenge provider not defined")
+		return nil, nil, fmt.Errorf("DNS challenge provider not defined")
 	}
 	// Config only needs to be set if it's defined, otherwise existing env/SDK
 	// defaults are fine.
@@ -647,10 +646,10 @@ func setDNSChallenge(client *lego.Client, m map[string]interface{}) error {
 	case "zoneee":
 		provider, err = zoneee.NewDNSProvider()
 	default:
-		return fmt.Errorf("%s: unsupported DNS challenge provider", providerName)
+		return nil, nil, fmt.Errorf("%s: unsupported DNS challenge provider", providerName)
 	}
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	var opts []dns01.ChallengeOption
@@ -663,11 +662,7 @@ func setDNSChallenge(client *lego.Client, m map[string]interface{}) error {
 		opts = append(opts, dns01.AddRecursiveNameservers(s))
 	}
 
-	if err := client.Challenge.SetDNS01Provider(provider, opts...); err != nil {
-		return err
-	}
-
-	return nil
+	return provider, opts, nil
 }
 
 // stringSlice converts an interface slice to a string slice.

--- a/acme/acme_structure.go
+++ b/acme/acme_structure.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-acme/lego/certcrypto"
 	"github.com/go-acme/lego/certificate"
 	"github.com/go-acme/lego/challenge"
-	"github.com/go-acme/lego/challenge/dns01"
 	"github.com/go-acme/lego/lego"
 	"github.com/go-acme/lego/providers/dns/acmedns"
 	"github.com/go-acme/lego/providers/dns/alidns"
@@ -160,13 +159,13 @@ func certificateSchema() map[string]*schema.Schema {
 						ValidateFunc: validateDNSChallengeConfig,
 						Sensitive:    true,
 					},
-					"recursive_nameservers": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
 				},
 			},
+		},
+		"recursive_nameservers": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"must_staple": {
 			Type:     schema.TypeBool,
@@ -508,7 +507,7 @@ func mapEnvironmentVariableValues(keyMapping map[string]string) {
 // setDNSChallenge takes a *lego.Client and the DNS challenge complex
 // structure as a map[string]interface{}, and configues the client to
 // only allow a DNS challenge with the configured provider.
-func setDNSChallenge(client *lego.Client, m map[string]interface{}) (challenge.Provider, []dns01.ChallengeOption, error) {
+func setDNSChallenge(client *lego.Client, m map[string]interface{}) (challenge.Provider, error) {
 	var provider challenge.Provider
 	var err error
 	var providerName string
@@ -516,7 +515,7 @@ func setDNSChallenge(client *lego.Client, m map[string]interface{}) (challenge.P
 	if v, ok := m["provider"]; ok && v.(string) != "" {
 		providerName = v.(string)
 	} else {
-		return nil, nil, fmt.Errorf("DNS challenge provider not defined")
+		return nil, fmt.Errorf("DNS challenge provider not defined")
 	}
 	// Config only needs to be set if it's defined, otherwise existing env/SDK
 	// defaults are fine.
@@ -646,23 +645,13 @@ func setDNSChallenge(client *lego.Client, m map[string]interface{}) (challenge.P
 	case "zoneee":
 		provider, err = zoneee.NewDNSProvider()
 	default:
-		return nil, nil, fmt.Errorf("%s: unsupported DNS challenge provider", providerName)
+		return nil, fmt.Errorf("%s: unsupported DNS challenge provider", providerName)
 	}
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	var opts []dns01.ChallengeOption
-	if nameservers := m["recursive_nameservers"].([]interface{}); len(nameservers) > 0 {
-		var s []string
-		for _, ns := range nameservers {
-			s = append(s, ns.(string))
-		}
-
-		opts = append(opts, dns01.AddRecursiveNameservers(s))
-	}
-
-	return provider, opts, nil
+	return provider, nil
 }
 
 // stringSlice converts an interface slice to a string slice.

--- a/acme/acme_structure_test.go
+++ b/acme/acme_structure_test.go
@@ -200,6 +200,7 @@ func TestACME_certificateSchema(t *testing.T) {
 		"certificate_request_pem",
 		"min_days_remaining",
 		"dns_challenge",
+		"recursive_nameservers",
 		"must_staple",
 		"certificate_domain",
 		"private_key_pem",
@@ -284,7 +285,7 @@ func TestACME_setDNSChallenge_noProvider(t *testing.T) {
 		t.Fatalf("fatal: %s", err.Error())
 	}
 
-	_, _, err = setDNSChallenge(client, m)
+	_, err = setDNSChallenge(client, m)
 	if err == nil {
 		t.Fatalf("should have errored due to no provider supplied")
 	}
@@ -301,7 +302,7 @@ func TestACME_setDNSChallenge_unsuppotedProvider(t *testing.T) {
 		t.Fatalf("fatal: %s", err.Error())
 	}
 
-	_, _, err = setDNSChallenge(client, m)
+	_, err = setDNSChallenge(client, m)
 	if err == nil {
 		t.Fatalf("should have errored due to unknown provider")
 	}

--- a/acme/acme_structure_test.go
+++ b/acme/acme_structure_test.go
@@ -284,7 +284,7 @@ func TestACME_setDNSChallenge_noProvider(t *testing.T) {
 		t.Fatalf("fatal: %s", err.Error())
 	}
 
-	err = setDNSChallenge(client, m)
+	_, _, err = setDNSChallenge(client, m)
 	if err == nil {
 		t.Fatalf("should have errored due to no provider supplied")
 	}
@@ -301,7 +301,7 @@ func TestACME_setDNSChallenge_unsuppotedProvider(t *testing.T) {
 		t.Fatalf("fatal: %s", err.Error())
 	}
 
-	err = setDNSChallenge(client, m)
+	_, _, err = setDNSChallenge(client, m)
 	if err == nil {
 		t.Fatalf("should have errored due to unknown provider")
 	}

--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -6,8 +6,43 @@ import (
 	"log"
 
 	"github.com/go-acme/lego/certificate"
+	"github.com/go-acme/lego/challenge"
+	"github.com/go-acme/lego/challenge/dns01"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/helper/schema"
 )
+
+type DNSProviderWrapper struct {
+	providers []challenge.Provider
+}
+
+func NewDNSProviderWrapper() (*DNSProviderWrapper, error) {
+	return &DNSProviderWrapper{}, nil
+}
+
+func (d *DNSProviderWrapper) Present(domain, token, keyAuth string) error {
+	var err error
+	for _, p := range d.providers {
+		err = p.Present(domain, token, keyAuth)
+		if err != nil {
+			err = multierror.Append(err, fmt.Errorf("error encountered while presenting token for DNS challenge: %s", err.Error()))
+		}
+	}
+
+	return err
+}
+
+func (d *DNSProviderWrapper) CleanUp(domain, token, keyAuth string) error {
+	var err error
+	for _, p := range d.providers {
+		err = p.CleanUp(domain, token, keyAuth)
+		if err != nil {
+			err = multierror.Append(err, fmt.Errorf("error encountered while cleaning token for DNS challenge: %s", err.Error()))
+		}
+	}
+
+	return err
+}
 
 func resourceACMECertificate() *schema.Resource {
 	return &schema.Resource{
@@ -29,9 +64,22 @@ func resourceACMECertificateCreate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	if err = setDNSChallenge(client, d.Get("dns_challenge").([]interface{})[0].(map[string]interface{})); err != nil {
+	provider, err := NewDNSProviderWrapper()
+	if err != nil {
 		return err
 	}
+
+	var challenge_opts []dns01.ChallengeOption
+	for _, v := range d.Get("dns_challenge").([]interface{}) {
+		if p, opts, err := setDNSChallenge(client, v.(map[string]interface{})); err == nil {
+			provider.providers = append(provider.providers, p)
+			challenge_opts = append(challenge_opts, opts...)
+		} else {
+			return err
+		}
+	}
+
+	client.Challenge.SetDNS01Provider(provider)
 
 	var cert *certificate.Resource
 
@@ -83,6 +131,22 @@ func resourceACMECertificateRead(d *schema.ResourceData, meta interface{}) error
 // resourceACMECertificateCustomizeDiff checks the certificate for renewal and
 // flags it as NewComputed if it needs a renewal.
 func resourceACMECertificateCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
+	// Ensure duplicate providers for dns_challenge are not provided.
+	provider_map := make(map[string]bool)
+	for _, v := range d.Get("dns_challenge").([]interface{}) {
+		m := v.(map[string]interface{})
+		if v, ok := m["provider"]; ok && v.(string) != "" {
+			provider := v.(string)
+			if _, ok := provider_map[provider]; ok {
+				return fmt.Errorf("duplicate dns_challenge providers: %s", provider)
+			} else {
+				provider_map[provider] = true
+			}
+		} else {
+			return fmt.Errorf("DNS challenge provider not defined")
+		}
+	}
+
 	// There's nothing for us to do in a Create diff, so if there's no ID yet,
 	// just pass this part.
 	if d.Id() == "" {
@@ -130,9 +194,23 @@ func resourceACMECertificateUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	cert := expandCertificateResource(d)
-	if err := setDNSChallenge(client, d.Get("dns_challenge").([]interface{})[0].(map[string]interface{})); err != nil {
+
+	provider, err := NewDNSProviderWrapper()
+	if err != nil {
 		return err
 	}
+
+	var challenge_opts []dns01.ChallengeOption
+	for _, v := range d.Get("dns_challenge").([]interface{}) {
+		if p, opts, err := setDNSChallenge(client, v.(map[string]interface{})); err == nil {
+			provider.providers = append(provider.providers, p)
+			challenge_opts = append(challenge_opts, opts...)
+		} else {
+			return err
+		}
+	}
+
+	client.Challenge.SetDNS01Provider(provider)
 
 	newCert, err := client.Certificate.Renew(*cert, true, d.Get("must_staple").(bool))
 	if err != nil {

--- a/acme/resource_acme_certificate_test.go
+++ b/acme/resource_acme_certificate_test.go
@@ -711,6 +711,14 @@ resource "acme_certificate" "certificate" {
 
 func testAccACMECertificateConfigMultiProviders() string {
 	providers := strings.Split(os.Getenv("ACME_MULTI_PROVIDERS"), ",")
+	if len(providers) < 2 {
+		// This is a workaround just to make sure we don't get a panic
+		// when the config is generated for the TestCase literal. This
+		// test should be skipped or error out if ACME_MULTI_PROVIDERS is
+		// not properly defiend.
+		providers = make([]string, 2)
+	}
+
 	return fmt.Sprintf(`
 variable "email_address" {
   default = "%s"

--- a/acme/resource_acme_certificate_test.go
+++ b/acme/resource_acme_certificate_test.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -215,6 +216,29 @@ func TestAccACMECertificate_p12Password(t *testing.T) {
 	})
 }
 
+func TestAccACMECertificate_multiProviders(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCert(t)
+			testAccPreCheckCertMultiProviders(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccACMECertificateConfigMultiProviders(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"acme_certificate.certificate", "id",
+						"acme_certificate.certificate", "certificate_url",
+					),
+					testAccCheckACMECertificateValid("acme_certificate.certificate", "www14", "www15", false),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckACMECertificateValid(n, cn, san string, mustStaple bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -385,6 +409,17 @@ func testAccPreCheckCert(t *testing.T) {
 func testAccPreCheckCertZoneID(t *testing.T) {
 	if v := os.Getenv("ACME_R53_ZONE_ID"); v == "" {
 		t.Skip("ACME_R53_ZONE_ID must be set for the static configuration certificate acceptance test")
+	}
+}
+
+func testAccPreCheckCertMultiProviders(t *testing.T) {
+	if v := os.Getenv("ACME_MULTI_PROVIDERS"); v == "" {
+		t.Skip("ACME_MULTI_PROVIDERS must be set for the multiple providers certificate acceptance test")
+	} else {
+		providers := strings.Split(os.Getenv("ACME_MULTI_PROVIDERS"), ",")
+		if len(providers) != 2 {
+			t.Fatal("ACME_MULTI_PROVIDERS must specify exactly two providers")
+		}
 	}
 }
 
@@ -672,4 +707,40 @@ resource "acme_certificate" "certificate" {
 		os.Getenv("ACME_CERT_DOMAIN"),
 		password,
 	)
+}
+
+func testAccACMECertificateConfigMultiProviders() string {
+	providers := strings.Split(os.Getenv("ACME_MULTI_PROVIDERS"), ",")
+	return fmt.Sprintf(`
+variable "email_address" {
+  default = "%s"
+}
+
+variable "domain" {
+  default = "%s"
+}
+
+resource "tls_private_key" "private_key" {
+  algorithm = "RSA"
+}
+
+resource "acme_registration" "reg" {
+  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
+  email_address   = "${var.email_address}"
+}
+
+resource "acme_certificate" "certificate" {
+  account_key_pem           = "${acme_registration.reg.account_key_pem}"
+  common_name               = "www14.${var.domain}"
+  subject_alternative_names = ["www15.${var.domain}"]
+
+  dns_challenge {
+    provider = "%s"
+  }
+
+  dns_challenge {
+    provider = "%s"
+  }
+}
+`, os.Getenv("ACME_EMAIL_ADDRESS"), os.Getenv("ACME_CERT_DOMAIN"), providers[0], providers[1])
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/cloudflare/cloudflare-go v0.8.5 // indirect
 	github.com/cpu/goacmedns v0.0.1 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/decker502/dnspod-go v0.0.0-20180416134550-83a3ba562b04 // indirect
 	github.com/dimchansky/utfbom v1.1.0 // indirect
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
@@ -32,6 +33,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-getter v1.2.0 // indirect
 	github.com/hashicorp/go-hclog v0.9.1 // indirect
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/website/docs/dns_providers/index.html.markdown
+++ b/website/docs/dns_providers/index.html.markdown
@@ -34,8 +34,8 @@ resource for more details.
 
 ## Relation to Terraform provider configuration
 
-The DNS provider configuration specified in the
-[`acme_certificate`][resource-acme-certificate] resource is separate from any
+The DNS provider configurations specified in the
+[`acme_certificate`][resource-acme-certificate] resource are separate from any
 that you supply in a corresponding provider whose functionality overlaps with
 the certificate's DNS providers.  This ensures that there are no hard
 dependencies between any of these providers and the ACME provider, but it is


### PR DESCRIPTION
Multiple dns_challenge stanzas can now be specified to present the DNS challenge token. Previously, in situations with multiple primary DNS providers, the challenge may fail if only one provider was presented with the challenge token.

I am open to discussion on how this feature might be implemented. This was just my initial swing at a solution.