### PR TITLE
plugin: log lego's log messages in Terraform

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	legoLog "github.com/go-acme/lego/log"
+)
+
+// legoLogger is a proxy for lego log messages. This allows messages
+// for lego itself to be printed as actual plugin debug logs.
+//
+// Note that this log proxy only passes through messages, ignores log
+// levels, and does not exit on Fatal or its similar functions.  All
+// messages are logged at the debug level.
+type legoLogger struct{}
+
+// initLegoLogger initializes the logger and sets it up as an
+// override for the lego standard logger, which is ignored by
+// Terraform. This should be run in main, after lego has had a chance
+// to initialize the package singleton.
+func initLegoLogger() {
+	l := &legoLogger{}
+	legoLog.Logger = l
+	l.log("Messages from the lego library will show up as DEBUG messages.")
+}
+
+func (l *legoLogger) Fatal(args ...interface{})                 { l.log(args) }
+func (l *legoLogger) Fatalln(args ...interface{})               { l.log(args) }
+func (l *legoLogger) Fatalf(format string, args ...interface{}) { l.log(fmt.Sprintf(format, args...)) }
+func (l *legoLogger) Print(args ...interface{})                 { l.log(args) }
+func (l *legoLogger) Println(args ...interface{})               { l.log(args) }
+func (l *legoLogger) Printf(format string, args ...interface{}) { l.log(fmt.Sprintf(format, args...)) }
+
+// log logs the raw message sent to it to the Terraform logger with a
+// prefix indicating it came from lego.
+//
+// All messages are logged at the debug level.
+func (l *legoLogger) log(args ...interface{}) {
+	// Strip any lego-based log level from the string. This should
+	// always be in the first argument.
+	if len(args) > 0 {
+		if _, ok := args[0].(string); ok {
+			switch {
+			case strings.HasPrefix(args[0].(string), "[INFO] "):
+				args[0] = strings.TrimPrefix(args[0].(string), "[INFO] ")
+
+			case strings.HasPrefix(args[0].(string), "[WARN] "):
+				args[0] = strings.TrimPrefix(args[0].(string), "[WARN] ")
+			}
+		}
+	}
+
+	log.Println(append([]interface{}{"[DEBUG]", "lego:"}, args...)...)
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 )
 
 func main() {
+	initLegoLogger()
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: acme.Provider,
 	})


### PR DESCRIPTION
The lego library itself logs several useful messages during
operation, namely pertaining to the obtaining of authorizations and
resolution of challenges. However, the lego standard logger conflicts
with Terraform's and these messages do not get displayed.

This adds a lightweight lego StdLogger implementation to pass these
log messages through to the plugin's logging facilities, ensuring
these messages aren't lost.

Log level prefixes are stripped and the messages are ultimately
logged at the DEBUG level.