### PR TITLE
r/certificate: get certificate from CA if missing in state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/dnsimple/dnsimple-go v0.23.0 // indirect
 	github.com/exoscale/egoscale v0.14.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
-	github.com/go-acme/lego v2.5.0+incompatible
+	github.com/go-acme/lego v0.0.0-00010101000000-000000000000
 	github.com/go-ini/ini v1.42.0 // indirect
 	github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31 // indirect
 	github.com/golang/mock v1.3.0 // indirect
@@ -90,3 +90,5 @@ replace github.com/h2non/gock => gopkg.in/h2non/gock.v1 v1.0.14
 replace sourcegraph.com/sourcegraph/go-diff => github.com/sourcegraph/go-diff v0.5.1
 
 replace github.com/golang/lint => golang.org/x/lint v0.0.0-20190409202823-959b441ac422
+
+replace github.com/go-acme/lego => github.com/vancluever/lego v2.5.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,6 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
-github.com/go-acme/lego v2.5.0+incompatible h1:5fNN9yRQfv8ymH3DSsxla+4aYeQt2IgfZqHKVnK8f0s=
-github.com/go-acme/lego v2.5.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=
 github.com/go-ini/ini v1.42.0 h1:TWr1wGj35+UiWHlBA8er89seFXxzwFn11spilrrj+38=
 github.com/go-ini/ini v1.42.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -506,6 +504,8 @@ github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5/go.mod h1:hnLbHMwcvSihnD
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/vancluever/lego v2.5.1+incompatible h1:/u0xuSR+cL7MIf08zzjPyVDJpDNFr7b6YM8BWuqZpU4=
+github.com/vancluever/lego v2.5.1+incompatible/go.mod h1:0u68GupQjZkURCpA1ngdhQYlBLyLWiWd2SEHCbdW3LA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=

--- a/vendor/github.com/go-acme/lego/certificate/certificates.go
+++ b/vendor/github.com/go-acme/lego/certificate/certificates.go
@@ -464,6 +464,37 @@ func (c *Certifier) GetOCSP(bundle []byte) ([]byte, *ocsp.Response, error) {
 	return ocspResBytes, ocspRes, nil
 }
 
+// Get attempts to fetch the certificate at the supplied URL. The URL
+// is the same as what would normally be supplied at the Resource's
+// CertURL.
+//
+// The returned Resource will not have the PrivateKey and CSR fields
+// populated as these will not be available.
+//
+// If bundle is true, the Certificate field in the returned Resource
+// includes the issuer certificate.
+func (c *Certifier) Get(url string, bundle bool) (*Resource, error) {
+	cert, issuer, err := c.core.Certificates.Get(url, bundle)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the returned cert bundle so that we can grab the domain
+	// from the common name.
+	x509Certs, err := certcrypto.ParsePEMBundle(cert)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Resource{
+		Domain:            x509Certs[0].Subject.CommonName,
+		CertURL:           url,
+		CertStableURL:     url,
+		Certificate:       cert,
+		IssuerCertificate: issuer,
+	}, nil
+}
+
 func checkOrderStatus(order acme.Order) (bool, error) {
 	switch order.Status {
 	case acme.StatusValid:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -124,7 +124,7 @@ github.com/exoscale/egoscale
 github.com/fatih/color
 # github.com/fatih/structs v1.1.0
 github.com/fatih/structs
-# github.com/go-acme/lego v2.5.0+incompatible
+# github.com/go-acme/lego v0.0.0-00010101000000-000000000000 => github.com/vancluever/lego v2.5.1+incompatible
 github.com/go-acme/lego/log
 github.com/go-acme/lego/certcrypto
 github.com/go-acme/lego/certificate


### PR DESCRIPTION
An existing bug with certificate updates means that the
certificate_pem field will be dropped if there are errors renewing.

This does not correct that issue 100% (partial state is needed for
this), but what this *does* do is recover this field by fetching the
certificate data from the CA again if the certificate_pem field is
missing on refresh.

The actual fix to ensure the field is not cleared at all will be
coming in another commit.