### PR TITLE
r/certificate: use partial mode during certificate renewals

### DIFF
--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -416,6 +416,9 @@ func resourceACMECertificateUpdate(d *schema.ResourceData, meta interface{}) err
 		return nil
 	}
 
+	// Enable partial mode to protect the certificate during renewal
+	d.Partial(true)
+
 	client, _, err := expandACMEClient(d, meta, true)
 	if err != nil {
 		return err
@@ -461,6 +464,8 @@ func resourceACMECertificateUpdate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
+	// Complete, safe to turn off partial mode now.
+	d.Partial(false)
 	return nil
 }
 


### PR DESCRIPTION
This enables partial mode during the update process when the
certificate needs to be renewed.

This to prevent the resource from writing a bad diff if there is an
error during renewal. Specifically, certificate_pem being changed to
an unknown value during diff customization ultimately results in a
blank value being written if a new value is not set during update,
even in the event of an error.

PR #59 corrects existing states that may have been affected by this
issue by pulling the certificate_pem field directly from the CA.