### PR TITLE
r/registration: remove deactivated or deleted accounts on refresh

### DIFF
--- a/acme/resource_acme_certificate_test.go
+++ b/acme/resource_acme_certificate_test.go
@@ -110,7 +110,7 @@ func TestAccACMECertificate_forceRenewal(t *testing.T) {
 				Config: testAccACMECertificateForceRenewalConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					func(s *terraform.State) error {
-						certID = s.Modules[0].Resources["acme_certificate.certificate"].Primary.ID
+						certID = s.RootModule().Resources["acme_certificate.certificate"].Primary.ID
 						return nil
 					},
 					resource.TestCheckResourceAttrPair(


### PR DESCRIPTION
This change will remove a deactivated or deleted account from the
state if it's found on refresh. This will allow a destroy plan to
succeed when the account has already been deactivated or is otherwise
missing.

Note that once an account is deactivated, the private key is
unusable, so you cannot use this functionality to delete the resource
and recreate it. You must start a plan with a new private key.